### PR TITLE
setup users Home directory

### DIFF
--- a/7.2/x86/Dockerfile
+++ b/7.2/x86/Dockerfile
@@ -6,9 +6,9 @@ RUN mkdir -p /tmp/tce/optional \
     && chown -R root:staff /tmp/tce \
     && chmod -R g+w /tmp/tce \
     && $(cd etc/sysconfig; ln -s ../../tmp/tce tcedir) \
-    && echo -n > etc/sysconfig/tcuser \
-    && mkdir /home/tc \
-    && chown tc:staff /home/tc
+    && echo -n tc > etc/sysconfig/tcuser \
+    && . /etc/init.d/tc-functions \
+    && setupHome
 
 USER tc
 CMD ["/bin/sh"]

--- a/7.2/x86_64/Dockerfile
+++ b/7.2/x86_64/Dockerfile
@@ -6,9 +6,9 @@ RUN mkdir -p /tmp/tce/optional \
     && chown -R root:staff /tmp/tce \
     && chmod -R g+w /tmp/tce \
     && $(cd etc/sysconfig; ln -s ../../tmp/tce tcedir) \
-    && echo -n > etc/sysconfig/tcuser \
-    && mkdir /home/tc \
-    && chown tc:staff /home/tc
+    && echo -n tc > etc/sysconfig/tcuser \
+    && . /etc/init.d/tc-functions \
+    && setupHome
 
 USER tc
 CMD ["/bin/sh"]


### PR DESCRIPTION
name the user so extension install scripts work, extensions like bash.tcz read /etc/sysconfig/tcuser to get the user name

Call the built-in setupHome script from /etc/init.d/tc-functions to initialize users home directory. This does extra work beyond just creating the directory and assigning ownership. 