### PR TITLE
Patch missing in alpine to build tinycore container image.

### DIFF
--- a/11.0/x86/src/Dockerfile
+++ b/11.0/x86/src/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
 ADD tce-load.patch /tmp/
-RUN apk add --no-cache curl \
+RUN apk add --no-cache curl patch \
     && curl -SLO http://www.tinycorelinux.net/11.x/x86/release/distribution_files/rootfs.gz \
     && mkdir rootfs \
     && cd rootfs \

--- a/11.0/x86_64/src/Dockerfile
+++ b/11.0/x86_64/src/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
 ADD tce-load.patch /tmp/
-RUN apk add --no-cache curl \
+RUN apk add --no-cache curl patch \
     && curl -SLO http://www.tinycorelinux.net/11.x/x86_64/release/distribution_files/rootfs64.gz \
     && mkdir rootfs64 \
     && cd rootfs64 \


### PR DESCRIPTION
Add alpine patch package to src/Dockerfile to fix build of tinycore 11.0 x86 and x86_64 container images.

See also 
- https://github.com/boot2podman/boot2podman/pull/23 (PR) 
- https://github.com/boot2podman/boot2podman/issues/22 (Issue)